### PR TITLE
fix crash on MACOS

### DIFF
--- a/tools/grammar.c
+++ b/tools/grammar.c
@@ -274,8 +274,11 @@ ParseFile (char *szPath)
    while ((fgets (szLine, 4096, fp) != NULL) && (nRetCode >= 0))
      {
         nLineNumber += 1;
-        if ((cp = strchr (szLine, '\n')))
-           *cp = '\0';
+        if ((cp = strchr (szLine, '\n'))) {
+          *cp = '\0';
+          if ((cp = strchr (szLine, '\r'))) 
+            *cp = '\0';
+        }
         else
            ReportError (QERR_LINE_TOO_LONG, NULL, 1);
 


### PR DESCRIPTION
text file ends a line with "\r\n" on MACOS. If don't remove '\r' in the end of a line, it will be treated as syntax error then leads a crash.