### PR TITLE
fix: Add explicit arg typing across `tools/*`.

### DIFF
--- a/tools/date.c
+++ b/tools/date.c
@@ -563,7 +563,7 @@ day_number(date_t *d)
  * TODO: None
  */
 int
-getDateWeightFromJulian(jDay, nDistribution)
+getDateWeightFromJulian(int jDay, int nDistribution)
 {
 	date_t dTemp;
 	int nDay;

--- a/tools/tdef_functions.c
+++ b/tools/tdef_functions.c
@@ -171,7 +171,7 @@ table_func_t s_tdef_funcs[] = {
 };
 
 table_func_t *
-getTdefFunctionsByNumber(nTable)
+getTdefFunctionsByNumber(int nTable)
 {
    if (nTable >= S_BRAND)
       return(&s_tdef_funcs[nTable - S_BRAND]);

--- a/tools/tdefs.c
+++ b/tools/tdefs.c
@@ -147,7 +147,7 @@ getTdefsByNumber(int nTable)
 }
 */
 tdef *
-getSimpleTdefsByNumber(nTable)
+getSimpleTdefsByNumber(int nTable)
 {
    if (nTable >= S_BRAND)
       return(&s_tdefs[nTable - S_BRAND]);


### PR DESCRIPTION
# fix: Add explicit arg typing across `tools/*`.

## Context

Some of the arguments in the functions located in `tool/*` do not explicitly define their type. This results in a compilation error.

Since the [C99 Standard](https://en.wikipedia.org/wiki/C99) requires explicit typing in function definitions.

## Changes

This PR will add typing to the function definitions.

