### PR TITLE
Fix compiler issues in function signatures

### DIFF
--- a/tools/date.c
+++ b/tools/date.c
@@ -549,7 +549,7 @@ day_number(date_t *d)
 }
 
 /*
- * Routine: getDateWeightFromJulian(jDay, nDistribution)
+ * Routine: getDateWeightFromJulian(int jDay, int nDistribution)
  * Purpose: return the weight associated with a particular julian date and distribution
  * Algorithm:
  * Data Structures:
@@ -563,7 +563,7 @@ day_number(date_t *d)
  * TODO: None
  */
 int
-getDateWeightFromJulian(jDay, nDistribution)
+getDateWeightFromJulian(int jDay, int nDistribution)
 {
 	date_t dTemp;
 	int nDay;

--- a/tools/tdef_functions.c
+++ b/tools/tdef_functions.c
@@ -171,7 +171,7 @@ table_func_t s_tdef_funcs[] = {
 };
 
 table_func_t *
-getTdefFunctionsByNumber(nTable)
+getTdefFunctionsByNumber(int nTable)
 {
    if (nTable >= S_BRAND)
       return(&s_tdef_funcs[nTable - S_BRAND]);

--- a/tools/tdefs.c
+++ b/tools/tdefs.c
@@ -147,7 +147,7 @@ getTdefsByNumber(int nTable)
 }
 */
 tdef *
-getSimpleTdefsByNumber(nTable)
+getSimpleTdefsByNumber(int nTable)
 {
    if (nTable >= S_BRAND)
       return(&s_tdefs[nTable - S_BRAND]);


### PR DESCRIPTION
The compiler does not allow function signatures like "myfun(arg)". We need to add a type of arg explicitly.