### PR TITLE
Fix -filter flag and extend stdout streaming to returns tables

### DIFF
--- a/tools/driver.c
+++ b/tools/driver.c
@@ -76,7 +76,7 @@ extern char *optarg;
 char g_szCommandLine[201];
 file_ref_t CurrentFile;
 file_ref_t *pCurrentFile;
-int g_filter_tabid = -1; /* table routed to stdout when FILTER is set; -1 = none */
+extern int g_filter_tabid; /* defined in print.c, linked into both dsdgen and dsqgen */
 
 
 /*

--- a/tools/driver.c
+++ b/tools/driver.c
@@ -76,6 +76,7 @@ extern char *optarg;
 char g_szCommandLine[201];
 file_ref_t CurrentFile;
 file_ref_t *pCurrentFile;
+int g_filter_tabid = -1; /* table routed to stdout when FILTER is set; -1 = none */
 
 
 /*
@@ -358,6 +359,9 @@ validate_options(void)
 		if (get_int("CHILD") < 1) strcat(msg, "CHILD must be >= 1\n");
 	}
 
+	if (is_set("FILTER") && !strcmp(get_str("TABLE"), "ALL"))
+		strcat(msg, "FILTER requires a specific table name (use -table <name>)\n");
+
 	if (strlen(msg)) usage(NULL, msg);
 
 	return;
@@ -468,6 +472,33 @@ main (int ac, char **av)
 	else if (is_set("ABREVIATION"))
 	{
 		tabid = find_table("ABREVIATION", get_str("ABREVIATION"));
+	}
+
+	/*
+	 * When filtering for a child (returns) table, run its parent generator
+	 * but route only the child table's output to stdout. Save the original
+	 * child tabid so print_start knows which table goes to stdout, then
+	 * redirect tabid to the parent so the generation loop runs the right builder.
+	 */
+	g_filter_tabid = tabid;
+	if (is_set("FILTER") && tabid != -1)
+	{
+		pT = getSimpleTdefsByNumber(tabid);
+		if (pT && (pT->flags & FL_CHILD))
+		{
+			int parent_tabid;
+			tdef *pParent;
+			for (parent_tabid = CALL_CENTER;
+				 (pParent = getSimpleTdefsByNumber(parent_tabid)) && pParent->name;
+				 parent_tabid++)
+			{
+				if ((pParent->flags & FL_PARENT) && pParent->nParam == tabid)
+				{
+					tabid = parent_tabid;
+					break;
+				}
+			}
+		}
 	}
 
 	for (i=(is_set("UPDATE"))?S_BRAND:CALL_CENTER; (pT = getSimpleTdefsByNumber(i)); i++)

--- a/tools/makefile
+++ b/tools/makefile
@@ -36,10 +36,15 @@
 #
 #
 ################
-## TARGET OS HERE
+## TARGET OS - auto-detected from uname, override by setting OS= on the command line
 ################
 # OS Values: AIX, LINUX, SOLARIS, NCR, HPUX, MACOS
-OS = LINUX
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Darwin)
+    OS = MACOS
+else
+    OS = LINUX
+endif
 ###########
 # No changes should be necessary below this point
 # Each compile variable is adjusted for the target platform using the OS setting above
@@ -56,9 +61,9 @@ CC		= $($(OS)_CC)
 # CFLAGS
 AIX_CFLAGS		= -q64 -O3 -D_LARGE_FILES
 HPUX_CFLAGS		= -O3 -Wall
-LINUX_CFLAGS	= -g -Wall
+LINUX_CFLAGS	= -g -Wall -Wno-implicit-int -Wno-deprecated-non-prototype -fcommon
 NCR_CFLAGS		= -g 
-MACOS_CFLAGS		= -g -Wall
+MACOS_CFLAGS		= -g -Wall -Wno-implicit-int -Wno-deprecated-non-prototype
 SOLARIS_CFLAGS	= -O3 -Wall
 SOL86_CFLAGS	= -O3 
 BASE_CFLAGS    	= -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -DYYDEBUG #-maix64 -DMEM_TEST 

--- a/tools/params.h
+++ b/tools/params.h
@@ -61,7 +61,7 @@ option_t options[] =
 {"CHILD",		OPT_INT,			17,"generate <n>th chunk of the parallelized data", NULL, "1"}, 
 {"CHKSEEDS",		OPT_FLG|OPT_HIDE,	18, "validate RNG usage for parallelism", NULL, "N"}, 
 {"RELEASE",		OPT_FLG,			19, "display the release information", printReleaseInfo, "N"}, 
-{"_FILTER",		OPT_FLG,			20, "output data to stdout", NULL, "N"}, 
+{"FILTER",		OPT_FLG,			20, "output data to stdout", NULL, "N"},
 {"VALIDATE",	OPT_FLG,			21, "produce rows for data validation", NULL, "N"}, 
 {"VCOUNT",		OPT_INT|OPT_ADV,	22, "set number of validation rows to be produced", NULL, "50"}, 
 {"VSUFFIX",		OPT_STR|OPT_ADV,	23, "set file suffix for data validation", NULL, ".vld"}, 

--- a/tools/print.c
+++ b/tools/print.c
@@ -55,7 +55,7 @@
 static FILE *fpOutfile = NULL;
 static FILE *fpDeleteFile;
 static char *arDeleteFiles[3] = {"", "delete_", "inventory_delete_"};
-extern int g_filter_tabid;
+int g_filter_tabid = -1; /* table routed to stdout when FILTER is set; -1 = none */
 
 static int current_table = -1;
 

--- a/tools/print.c
+++ b/tools/print.c
@@ -55,6 +55,7 @@
 static FILE *fpOutfile = NULL;
 static FILE *fpDeleteFile;
 static char *arDeleteFiles[3] = {"", "delete_", "inventory_delete_"};
+extern int g_filter_tabid;
 
 static int current_table = -1;
 
@@ -446,7 +447,29 @@ print_start (int tbl)
    current_table = tbl;
 
    if (is_set ("FILTER"))
-	   fpOutfile = stdout;
+   {
+	   if (tbl == g_filter_tabid)
+	   {
+		   /* this is the table the user asked for: stream it to stdout */
+		   fpOutfile = stdout;
+	   }
+	   else
+	   {
+		   /*
+		    * A parent table being run to generate a child: suppress its output.
+		    * Open /dev/null once and cache it so we don't reopen every row.
+		    */
+		   if (pTdef->outfile == NULL)
+		   {
+#ifdef WIN32
+			   pTdef->outfile = fopen("nul", "w");
+#else
+			   pTdef->outfile = fopen("/dev/null", "w");
+#endif
+		   }
+		   fpOutfile = pTdef->outfile;
+	   }
+   }
    else
    {
 	   if (pTdef->outfile == NULL)
@@ -454,9 +477,9 @@ print_start (int tbl)
 		   if (is_set("PARALLEL"))
 			   sprintf (path, "%s%c%s_%d_%d%s",
 			   get_str ("DIR"),
-			   PATH_SEP, getTableNameByID (tbl), 
+			   PATH_SEP, getTableNameByID (tbl),
 			   get_int("CHILD"), get_int("PARALLEL"), (is_set("VALIDATE"))?get_str ("VSUFFIX"):get_str ("SUFFIX"));
-		   else 
+		   else
 		   {
 			   if (is_set("UPDATE"))
 				   sprintf (path, "%s%c%s_%d%s",
@@ -480,9 +503,9 @@ print_start (int tbl)
 		   pTdef->outfile = fopen (path, "w");
 #endif
 	   }
+	   fpOutfile = pTdef->outfile;
    }
-   
-   fpOutfile = pTdef->outfile;
+
    res = (fpOutfile != NULL);
 
    if (!res)                    /* open failed! */

--- a/tools/w_catalog_sales.c
+++ b/tools/w_catalog_sales.c
@@ -52,6 +52,7 @@
 #include "permute.h"
 #include "params.h"
 #include "parallel.h"
+extern int g_filter_tabid;
 #include "scd.h"
 
 struct W_CATALOG_SALES_TBL g_w_catalog_sales;
@@ -214,15 +215,18 @@ mk_detail(void *row, int bPrint)
 	r->cs_promo_sk = mk_join (CS_PROMO_SK, PROMOTION, 1);
 	set_pricing(CS_PRICING, &r->cs_pricing);
 
-	/** 
+	/**
 	* having gone to the trouble to make the sale, now let's see if it gets returned
 	*/
-	genrand_integer(&nTemp, DIST_UNIFORM, 0, 99, 0, CR_IS_RETURNED);
-	if (nTemp < CR_RETURN_PCT)
+	if (!is_set("FILTER") || g_filter_tabid == CATALOG_RETURNS)
 	{
-		mk_w_catalog_returns(NULL, 1);
-      if (bPrint)
-         pr_w_catalog_returns(NULL);
+		genrand_integer(&nTemp, DIST_UNIFORM, 0, 99, 0, CR_IS_RETURNED);
+		if (nTemp < CR_RETURN_PCT)
+		{
+			mk_w_catalog_returns(NULL, 1);
+			if (bPrint)
+				pr_w_catalog_returns(NULL);
+		}
 	}
 
    /**

--- a/tools/w_store_sales.c
+++ b/tools/w_store_sales.c
@@ -50,6 +50,8 @@
 #include "permute.h"
 #include "scd.h"
 #include "parallel.h"
+#include "r_params.h"
+extern int g_filter_tabid;
 #ifdef JMS
 extern rng_t Streams[];
 #endif
@@ -135,15 +137,18 @@ tdef *pT = getSimpleTdefsByNumber(STORE_SALES);
 	r->ss_sold_promo_sk = mk_join (SS_SOLD_PROMO_SK, PROMOTION, 1);
 	set_pricing(SS_PRICING, &r->ss_pricing);
 
-	/** 
+	/**
 	* having gone to the trouble to make the sale, now let's see if it gets returned
 	*/
-	genrand_integer(&nTemp, DIST_UNIFORM, 0, 99, 0, SR_IS_RETURNED);
-	if (nTemp < SR_RETURN_PCT)
+	if (!is_set("FILTER") || g_filter_tabid == STORE_RETURNS)
 	{
-		mk_w_store_returns(&ReturnRow, 1);
-      if (bPrint)
-         pr_w_store_returns(&ReturnRow);
+		genrand_integer(&nTemp, DIST_UNIFORM, 0, 99, 0, SR_IS_RETURNED);
+		if (nTemp < SR_RETURN_PCT)
+		{
+			mk_w_store_returns(&ReturnRow, 1);
+			if (bPrint)
+				pr_w_store_returns(&ReturnRow);
+		}
 	}
 
    if (bPrint)

--- a/tools/w_web_sales.c
+++ b/tools/w_web_sales.c
@@ -53,6 +53,8 @@
 #include "permute.h"
 #include "scd.h"
 #include "parallel.h"
+#include "r_params.h"
+extern int g_filter_tabid;
 
 struct W_WEB_SALES_TBL g_w_web_sales;
 ds_key_t skipDays(int nTable, ds_key_t *pRemainder);
@@ -186,15 +188,18 @@ mk_detail (void *row, int bPrint)
       r->ws_promo_sk = mk_join (WS_PROMO_SK, PROMOTION, 1);
       set_pricing(WS_PRICING, &r->ws_pricing);
 
-      /** 
+      /**
       * having gone to the trouble to make the sale, now let's see if it gets returned
       */
-      genrand_integer(&nTemp, DIST_UNIFORM, 0, 99, 0, WR_IS_RETURNED);
-      if (nTemp < WR_RETURN_PCT)
+      if (!is_set("FILTER") || g_filter_tabid == WEB_RETURNS)
       {
-         mk_w_web_returns(&w_web_returns, 1);
-         if (bPrint)
-			 pr_w_web_returns(&w_web_returns);
+         genrand_integer(&nTemp, DIST_UNIFORM, 0, 99, 0, WR_IS_RETURNED);
+         if (nTemp < WR_RETURN_PCT)
+         {
+            mk_w_web_returns(&w_web_returns, 1);
+            if (bPrint)
+               pr_w_web_returns(&w_web_returns);
+         }
       }
 
       /**


### PR DESCRIPTION
## What was broken

The `-filter` flag (which streams generated data to stdout instead of writing
files) was silently broken by the v2.3.0 upstream import (`12caac0`), which
reverted three fixes Greg Rahn had originally landed in `7992dbb`:

1. **`params.h`**: Option was named `_FILTER` but `is_set()` searches for
   `"FILTER"` using prefix matching — it never matched, so filter mode never
   activated for any table.
2. **`print.c` (`print_start`)**: `fpOutfile = pTdef->outfile` ran
   unconditionally, overwriting the `stdout` assignment with `NULL` on every
   row.
3. **`w_store_sales.c`**: Returns generation ran even in filter mode, writing
   interleaved sales and returns rows to stdout in a single pass.

## What's new

- Restores all three fixes above
- Extends `-filter` support to the three returns tables (`store_returns`,
  `catalog_returns`, `web_returns`). Because returns are generated as a side
  effect of their parent sales table, a `g_filter_tabid` global tracks the
  target table; `driver.c` redirects child table requests to the parent
  generator, and `print_start` routes only the target to stdout, suppressing
  the parent's output to `/dev/null`.
- Auto-detects OS in `makefile` (`Darwin` → `MACOS`, else `LINUX`) so the
  same build works on macOS and Linux without a manual `OS=` override.
- Adds compiler flags for compatibility with modern GCC/clang on K&R-style C
  (`-Wno-implicit-int -Wno-deprecated-non-prototype -fcommon`).
- Adds a clear error when `-filter` is used without specifying `-table <name>`.

## Verification

Output verified byte-for-byte identical to non-filter mode for all tables.

## Usage

```bash
./dsdgen -scale N -table store_sales    -filter -quiet 2>/dev/null | gzip > store_sales.gz
./dsdgen -scale N -table store_returns  -filter -quiet 2>/dev/null | gzip > store_returns.gz
# same pattern for catalog_sales/returns, web_sales/returns
```